### PR TITLE
Use {bigreadr} 0.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     future (>= 1.14.0),
     data.table (>= 1.12.2),
     crayon (>= 1.3.4),
-    bigreadr (>= 0.1.9),
+    bigreadr (>= 0.2.0),
     bit64
 Depends:
     R (>= 3.5.0),


### PR DESCRIPTION
Fixed a bug in {bigreadr}'s `nlines()`.